### PR TITLE
fix: Allow arguments after "--"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,13 +124,18 @@ impl Lints {
     }
 
     pub fn clippy(&self, args: &[String]) -> Result<()> {
+        let mut split_args = args.splitn(2, |arg| arg == "--");
+        let pre_args = split_args.next().unwrap(); // Always exists
+        let post_args = split_args.next().unwrap_or(&[]);
+
         let code = Command::new("cargo")
             .arg("clippy")
-            .args(args)
+            .args(pre_args)
             .arg("--")
             .args(self.deny_flags())
             .args(self.warn_flags())
             .args(self.allow_flags())
+            .args(post_args)
             .spawn()
             .wrap_err("Failed to start clippy")?
             .wait()


### PR DESCRIPTION
Hi!

I have noticed that `cargo-lints` does not allow to specify any arguments after `--`, which results in that it cannot be used effectively in CI. Even for warning lints, in CI the command should fail, so for clippy it is executed like `cargo clippy --all-targets -- -D warnings` to deny all warnings.

I split the arguments into before "--" and after and then add them to the appropriate places, which allows more freedom and fixes this issue.

Thank you for your work :)